### PR TITLE
Add exit callback inside worker process.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-.venv2/
-.venv3/
+.venv*/
 
 # Installer logs
 pip-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-.venv/
+.venv2/
+.venv3/
 
 # Installer logs
 pip-log.txt

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 
 
 setup(name='provoke',
-      version='0.5.1',
+      version='0.6.0',
       author='Ian Good',
       author_email='icgood@gmail.com',
       description='Lightweight, asynchronous function execution in Python '

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -17,7 +17,7 @@ except ImportError:
 
 from provoke import worker as worker_mod
 from provoke.amqp import AmqpConnection
-from provoke.worker import _WorkerProcess, _LocalProcess, \
+from provoke.worker import WorkerProcess, _LocalProcess, _run_cb, \
     WorkerMaster, get_worker_data, get_worker_app, DiscardTask
 
 
@@ -33,6 +33,21 @@ class JsonMatcher(object):
         return True
 
 
+class TestRunCB(unittest.TestCase):
+
+    def test_run_cb(self):
+        obj = MagicMock()
+        obj.callback1.return_value = True
+        obj.callback2.side_effect = ValueError
+        obj.callback3.side_effect = DiscardTask
+        _run_cb(obj, 'callback1', 'test', stuff='data')
+        _run_cb(obj, 'callback2')
+        self.assertRaises(DiscardTask, _run_cb, obj, 'callback3')
+        obj.callback1.assert_called_once_with('test', stuff='data')
+        obj.callback2.assert_called_once_with()
+        obj.callback3.assert_called_once_with()
+
+
 class TestWorkerProcess(unittest.TestCase):
 
     def setUp(self):
@@ -43,7 +58,7 @@ class TestWorkerProcess(unittest.TestCase):
     @patch.object(AmqpConnection, '__exit__')
     def test_consume(self, amqp_exit_mock, amqp_enter_mock):
         app = MagicMock()
-        worker = _WorkerProcess(app, ['testqueue'], 1, exclusive='exclusive')
+        worker = WorkerProcess(app, ['testqueue'], 1, exclusive='exclusive')
         channel = MagicMock(callbacks=True)
 
         def set_done():
@@ -61,63 +76,78 @@ class TestWorkerProcess(unittest.TestCase):
 
     def test_send_result(self):
         channel = MagicMock()
-        worker = _WorkerProcess(None, None)
+        worker = WorkerProcess(None, None)
         worker._send_result(channel, 'testid', 'test', {})
         channel.basic_publish.assert_called_with(ANY, exchange='',
                                                  routing_key='test')
 
-    @patch.object(_WorkerProcess, '_send_result')
+    @patch.object(WorkerProcess, '_send_result')
     def test_on_message(self, send_result_mock):
+        class MyWorkerProcess(WorkerProcess):
+
+            def task_callback(self_, name, args, kwargs):
+                self.assertEqual('func', name)
+                self.assertEqual([1], args)
+                self.assertEqual({'two': 2}, kwargs)
+
+            def return_callback(self_, name, ret):
+                self.assertEqual('func', name)
+                self.assertEqual('return', ret)
+
         app = MagicMock()
-        task_cb = MagicMock()
-        return_cb = MagicMock()
         app.tasks.func.apply.return_value = 'return'
-        worker = _WorkerProcess(app, None, task_callback=task_cb,
-                                return_callback=return_cb)
+        worker = MyWorkerProcess(app, None)
         worker.counter = 0
         channel = MagicMock()
         body = '{"task": "func", "args": [1], "kwargs": {"two": 2}}'
         msg = MagicMock(body=body, correlation_id='testid', reply_to='test')
         worker._on_message(channel, msg)
-        task_cb.assert_called_with('func', [1], {'two': 2})
         app.tasks.func.apply.assert_called_with([1], {'two': 2}, 'testid')
         channel.basic_ack.assert_called_with(ANY)
-        return_cb.assert_called_with('func', 'return')
         send_result_mock.assert_called_with(channel, 'testid', 'test', ANY)
         self.assertFalse(channel.basic_cancel.called)
 
     def test_on_message_task_callback(self):
+        class MyWorkerProcess(WorkerProcess):
+
+            def task_callback(self_, name, args, kwargs):
+                self.assertEqual('func', name)
+                self.assertEqual([1], args)
+                self.assertEqual({'two': 2}, kwargs)
+                raise SystemExit
+
         app = MagicMock()
-        task_cb = MagicMock(side_effect=SystemExit)
-        worker = _WorkerProcess(app, None, task_callback=task_cb)
+        worker = MyWorkerProcess(app, None)
         worker.counter = 0
         channel = MagicMock(callbacks={1: None, 2: None})
         body = '{"task": "func", "args": [1], "kwargs": {"two": 2}}'
         msg = MagicMock(body=body, correlation_id='testid')
         self.assertRaises(SystemExit, worker._on_message, channel, msg)
-        task_cb.assert_called_with('func', [1], {'two': 2})
         self.assertFalse(app.tasks.func.apply.called)
         channel.basic_reject.assert_called_with(ANY, requeue=True)
 
     def test_on_message_task_callback_discardtask(self):
+        class MyWorkerProcess(WorkerProcess):
+
+            def task_callback(self_, name, args, kwargs):
+                self.assertEqual('func', name)
+                self.assertEqual([1], args)
+                self.assertEqual({'two': 2}, kwargs)
+                raise DiscardTask
+
         app = MagicMock()
-        task_cb = MagicMock(side_effect=DiscardTask)
-        return_cb = MagicMock()
-        worker = _WorkerProcess(app, None, task_callback=task_cb,
-                                return_callback=return_cb)
+        worker = MyWorkerProcess(app, None)
         worker.counter = 0
         channel = MagicMock(callbacks={1: None, 2: None})
         body = '{"task": "func", "args": [1], "kwargs": {"two": 2}}'
         msg = MagicMock(body=body, correlation_id='testid')
         worker._on_message(channel, msg)
-        task_cb.assert_called_with('func', [1], {'two': 2})
         self.assertFalse(app.tasks.func.apply.called)
-        self.assertFalse(return_cb.called)
         channel.basic_ack.assert_called_with(ANY)
 
     def test_on_message_limit(self):
         app = MagicMock()
-        worker = _WorkerProcess(app, None, 1)
+        worker = WorkerProcess(app, None, 1)
         worker.counter = 0
         channel = MagicMock(callbacks={1: None, 2: None})
 
@@ -132,19 +162,17 @@ class TestWorkerProcess(unittest.TestCase):
         channel.basic_cancel.assert_any_call(1)
         channel.basic_cancel.assert_any_call(2)
 
-    @patch.object(_WorkerProcess, '_send_result')
+    @patch.object(WorkerProcess, '_send_result')
     def test_on_message_task_fail(self, send_result_mock):
         app = MagicMock()
-        return_cb = MagicMock()
         app.tasks.func.apply.side_effect = ValueError
-        worker = _WorkerProcess(app, None, 2, return_callback=return_cb)
+        worker = WorkerProcess(app, None, 2)
         worker.counter = 0
         channel = MagicMock()
         body = '{"task": "func", "args": [1], "kwargs": {"two": 2}}'
         msg = MagicMock(body=body, correlation_id='testid', reply_to='test')
         self.assertRaises(ValueError, worker._on_message, channel, msg)
         app.tasks.func.apply.assert_called_with([1], {'two': 2}, 'testid')
-        return_cb.assert_called_with('func', None)
         send_result_mock.assert_called_with(channel, 'testid', 'test', ANY)
         channel.basic_reject.assert_called_with(ANY, requeue=False)
         self.assertFalse(channel.basic_cancel.called)
@@ -152,7 +180,7 @@ class TestWorkerProcess(unittest.TestCase):
     @patch.object(time, 'sleep')
     def test_send_heartbeats(self, sleep_mock):
         sleep_mock.side_effect = [None, Exception, StopIteration]
-        worker = _WorkerProcess(None, None, 1)
+        worker = WorkerProcess(None, None, 1)
         worker.active_connection = conn = MagicMock(heartbeat=30.0)
         self.assertRaises(StopIteration, worker._send_heartbeats)
         self.assertEqual(1, conn.send_heartbeat.call_count)
@@ -163,28 +191,22 @@ class TestWorkerProcess(unittest.TestCase):
     @patch.object(threading, 'Thread')
     def test_run(self, thread_cls_mock):
         thread_cls_mock.return_value = thread_mock = MagicMock()
-        worker_task_callback = MagicMock()
-        worker = _WorkerProcess('testapp', ['testqueue'], 10,
-                                task_callback=worker_task_callback)
+        worker = WorkerProcess('testapp', ['testqueue'], 10)
         worker._consume = MagicMock(side_effect=SystemExit)
         worker._run()
         thread_cls_mock.assert_called_with(target=ANY)
         thread_mock.start.assert_called_with()
-        self.assertFalse(worker_task_callback.called)
         worker._consume.assert_called_with()
 
     @patch.object(time, 'sleep')
     @patch.object(threading, 'Thread')
     def test_run_accessrefused(self, thread_cls_mock, sleep_mock):
         thread_cls_mock.return_value = thread_mock = MagicMock()
-        worker_task_callback = MagicMock()
-        worker = _WorkerProcess('testapp', ['testqueue'], 10,
-                                task_callback=worker_task_callback)
+        worker = WorkerProcess('testapp', ['testqueue'], 10)
         worker._consume = MagicMock(side_effect=[AccessRefused, None])
         worker._run()
         thread_cls_mock.assert_called_with(target=ANY)
         thread_mock.start.assert_called_with()
-        self.assertFalse(worker_task_callback.called)
         sleep_mock.assert_called_once_with(ANY)
         worker._consume.assert_called_with()
 
@@ -192,14 +214,11 @@ class TestWorkerProcess(unittest.TestCase):
     @patch.object(threading, 'Thread')
     def test_run_exception(self, thread_cls_mock, print_exc_mock):
         thread_cls_mock.return_value = thread_mock = MagicMock()
-        worker_task_callback = MagicMock()
-        worker = _WorkerProcess('testapp', ['testqueue'], 10,
-                                task_callback=worker_task_callback)
+        worker = WorkerProcess('testapp', ['testqueue'], 10)
         worker._consume = MagicMock(side_effect=AssertionError)
         self.assertRaises(AssertionError, worker._run)
         thread_cls_mock.assert_called_with(target=ANY)
         thread_mock.start.assert_called_with()
-        self.assertFalse(worker_task_callback.called)
         print_exc_mock.assert_called_with()
         worker._consume.assert_called_with()
 
@@ -224,20 +243,6 @@ class TestWorkerMaster(unittest.TestCase):
     def setUp(self):
         worker_mod._current_worker_data = {}
         worker_mod._current_worker_app = None
-
-    def test_start_callback(self):
-        cb = MagicMock(side_effect=Exception)
-        worker = MagicMock(queues='testqueues', pid='testpid')
-        master = WorkerMaster(start_callback=cb)
-        master.start_callback(worker)
-        cb.assert_called_with('testqueues', 'testpid')
-
-    def test_exit_callback(self):
-        cb = MagicMock(side_effect=Exception)
-        worker = MagicMock(queues='testqueues', pid='testpid')
-        master = WorkerMaster('testapp', exit_callback=cb)
-        master.exit_callback(worker, 'teststatus')
-        cb.assert_called_with('testqueues', 'testpid', 'teststatus')
 
     def test_add_worker(self):
         master = WorkerMaster()
@@ -272,33 +277,28 @@ class TestWorkerMaster(unittest.TestCase):
 
     @patch.object(os, 'waitpid')
     def test_check_workers(self, waitpid_mock):
-        exit_cb = MagicMock()
         worker = MagicMock(queues='testqueues', pid='testpid')
-        master = WorkerMaster('testapp', exit_callback=exit_cb)
+        master = WorkerMaster()
         master.workers = [worker]
         waitpid_mock.return_value = ('testpid', 0)
         self.assertTrue(master._check_workers())
         waitpid_mock.assert_called_with(0, 0)
-        exit_cb.assert_called_with('testqueues', 'testpid', 0)
         self.assertEqual(None, worker.pid)
 
     @patch.object(os, 'waitpid')
     def test_check_workers_no_children(self, waitpid_mock):
-        exit_cb = MagicMock()
         worker = MagicMock(queues='testqueues', pid='testpid')
-        master = WorkerMaster('testapp', exit_callback=exit_cb)
+        master = WorkerMaster()
         master.workers = [worker]
         waitpid_mock.side_effect = OSError(errno.ECHILD, 'No child processes')
         self.assertFalse(master._check_workers())
         waitpid_mock.assert_called_with(0, 0)
-        exit_cb.assert_called_with('testqueues', 'testpid', None)
         self.assertEqual(None, worker.pid)
 
     @patch.object(os, 'waitpid')
     def test_check_workers_other_oserror(self, waitpid_mock):
-        exit_cb = MagicMock()
         worker = MagicMock(queues='testqueues', pid='testpid')
-        master = WorkerMaster('testapp', exit_callback=exit_cb)
+        master = WorkerMaster()
         master.workers = [worker]
         waitpid_mock.side_effect = OSError(99, 'Something else')
         self.assertRaises(OSError, master._check_workers)
@@ -309,9 +309,9 @@ class TestWorkerMaster(unittest.TestCase):
     @patch.object(os, '_exit')
     def test_start_worker_child(self, exit_mock, fork_mock):
         app = MagicMock()
-        worker = _WorkerProcess(app, ['testqueue'])
+        worker = WorkerProcess(app, ['testqueue'])
         worker._run = MagicMock()
-        master = WorkerMaster('testapp')
+        master = WorkerMaster()
         fork_mock.return_value = 0
         master._start_worker(worker)
         fork_mock.assert_called_with()
@@ -321,7 +321,7 @@ class TestWorkerMaster(unittest.TestCase):
     @patch.object(os, 'fork')
     def test_start_worker_parent(self, fork_mock):
         worker = MagicMock()
-        master = WorkerMaster('testapp')
+        master = WorkerMaster()
         fork_mock.return_value = 13
         self.assertEqual(13, master._start_worker(worker))
         fork_mock.assert_called_with()
@@ -330,9 +330,9 @@ class TestWorkerMaster(unittest.TestCase):
     @patch.object(os, '_exit')
     def test_get_worker_data(self, exit_mock, fork_mock):
         app = MagicMock()
-        worker = _WorkerProcess(app, ['testqueue'])
+        worker = WorkerProcess(app, ['testqueue'])
         worker._run = MagicMock()
-        master = WorkerMaster('testapp', worker_data={'test': 'data'})
+        master = WorkerMaster(worker_data={'test': 'data'})
         fork_mock.return_value = 0
         self.assertRaises(RuntimeError, get_worker_data, 'test')
         master._start_worker(worker)
@@ -345,9 +345,9 @@ class TestWorkerMaster(unittest.TestCase):
     @patch.object(os, '_exit')
     def test_get_worker_app(self, exit_mock, fork_mock):
         app = MagicMock()
-        worker = _WorkerProcess(app, ['testqueue'])
+        worker = WorkerProcess(app, ['testqueue'])
         worker._run = MagicMock()
-        master = WorkerMaster('testapp')
+        master = WorkerMaster()
         fork_mock.return_value = 0
         self.assertRaises(RuntimeError, get_worker_app)
         master._start_worker(worker)
@@ -357,15 +357,13 @@ class TestWorkerMaster(unittest.TestCase):
         exit_mock.assert_called_with(os.EX_OK)
 
     def test_restart_workers(self):
-        start_cb = MagicMock()
         worker1 = MagicMock(queues='testqueues', pid='testpid1')
         worker2 = MagicMock(queues='testqueues', pid=None)
-        master = WorkerMaster(start_callback=start_cb)
+        master = WorkerMaster()
         master._start_worker = MagicMock(return_value='testpid2')
         master.workers = [worker1, worker2]
         master._restart_workers()
         master._start_worker.assert_called_once_with(worker2)
-        start_cb.assert_called_with('testqueues', 'testpid2')
 
     @patch.object(os, 'kill')
     def test_stop_workers(self, kill_mock):
@@ -375,7 +373,7 @@ class TestWorkerMaster(unittest.TestCase):
         worker1 = MagicMock(pid='testpid1')
         worker2 = MagicMock(pid='testpid2')
         worker3 = MagicMock(pid='testpid3')
-        master = WorkerMaster('testapp')
+        master = WorkerMaster()
         master.workers = [worker1, worker2, worker3]
         self.assertRaises(OSError, master._stop_workers)
         kill_mock.assert_any_call('testpid1', signal.SIGTERM)
@@ -384,24 +382,21 @@ class TestWorkerMaster(unittest.TestCase):
 
     @patch.object(os, 'waitpid')
     def test_wait(self, waitpid_mock):
-        exit_cb = MagicMock()
         waitpid_mock.side_effect = [('testpid1', 0),
                                     OSError(errno.ESRCH, 'No such pid'),
                                     OSError(99, 'Something else')]
         worker1 = MagicMock(queues=None, pid='testpid1')
         worker2 = MagicMock(queues=None, pid='testpid2')
         worker3 = MagicMock(queues=None, pid='testpid3')
-        master = WorkerMaster('testapp', exit_callback=exit_cb)
+        master = WorkerMaster()
         master.workers = [worker1, worker2, worker3]
         self.assertRaises(OSError, master.wait)
         waitpid_mock.assert_any_call('testpid1', 0)
         waitpid_mock.assert_any_call('testpid2', 0)
         waitpid_mock.assert_any_call('testpid3', 0)
-        exit_cb.assert_any_call(None, 'testpid1', 0)
-        exit_cb.assert_any_call(None, 'testpid2', None)
 
     def test_run(self):
-        master = WorkerMaster('testapp')
+        master = WorkerMaster()
         master._restart_workers = MagicMock(side_effect=[None, ValueError])
         master._check_workers = MagicMock()
         master._stop_workers = MagicMock()


### PR DESCRIPTION
The added functionality of this PR is an additional callback that runs before a worker process exits, whether by success or failure. This callback may be used to, for example, inspect the error condition for problems that can and should be fixed before the worker process is replaced.

Because the parameterized callbacks were getting a little out-of-hand, this PR also refactors the callbacks into methods that must be overridden by class inheritance.
