### PR TITLE
Call start_callback when worker is started

### DIFF
--- a/provoke/worker/__init__.py
+++ b/provoke/worker/__init__.py
@@ -439,7 +439,6 @@ class WorkerMaster(object):
             _current_worker_data = self._worker_data.copy()
             _current_worker_app = worker.app
             _run_cb(self, 'process_callback')
-            _run_cb(self, 'start_callback')
             _run_cb(worker, 'start_callback')
             try:
                 worker._run()

--- a/provoke/worker/__init__.py
+++ b/provoke/worker/__init__.py
@@ -439,7 +439,8 @@ class WorkerMaster(object):
             _current_worker_data = self._worker_data.copy()
             _current_worker_app = worker.app
             _run_cb(self, 'process_callback')
-            _run_cb(worker, 'process_callback')
+            _run_cb(self, 'start_callback')
+            _run_cb(worker, 'start_callback')
             try:
                 worker._run()
             except Exception:


### PR DESCRIPTION
@RSEmail/rsemail 

The 'start_callback' should be invoked when starting a WorkerProcess.
